### PR TITLE
chore(deps): bump GitHub Actions dependencies (#67)

### DIFF
--- a/.github/workflows/auto-add-issue-to-project.yml
+++ b/.github/workflows/auto-add-issue-to-project.yml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.5.0
+      - uses: actions/add-to-project@v1.0.2
         with:
           project-url: https://github.com/orgs/TeckVeho/projects/165
           github-token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/cd-gcp.yml
+++ b/.github/workflows/cd-gcp.yml
@@ -47,9 +47,9 @@ jobs:
     outputs:
       build_mode: ${{ steps.resolve.outputs.build_mode }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         if: github.event_name == 'push'
         id: filter
         with:
@@ -85,7 +85,7 @@ jobs:
     environment: ${{ github.ref_name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Resolve Cloud Build config
         id: cfg
@@ -173,13 +173,13 @@ jobs:
           fi
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Verify Cloud Build access to target project
         env:

--- a/.github/workflows/deploy-aws.yml
+++ b/.github/workflows/deploy-aws.yml
@@ -13,14 +13,14 @@ jobs:
         working-directory: backend
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup SSH
         uses: ./.github/actions/setup-ssh
         with:
           ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
           host: ${{ secrets.SSH_HOST }}
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -58,13 +58,13 @@ jobs:
         working-directory: frontend
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Setup SSH
         uses: ./.github/actions/setup-ssh
         with:
           ssh_key: ${{ secrets.SSH_PRIVATE_KEY }}
           host: ${{ secrets.SSH_HOST }}
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ vars.NODE_VERSION }}
 


### PR DESCRIPTION
## Summary

Bumps GitHub Actions dependencies tracked in #67.

### Updates

| Action | From | To |
| --- | --- | --- |
| `actions/add-to-project` | 0.5.0 | 1.0.2 |
| `actions/checkout` | v3/v4 | v6 |
| `dorny/paths-filter` | v3 | v4 |
| `google-github-actions/auth` | v2 | v3 |
| `google-github-actions/setup-gcloud` | v2 | v3 |
| `actions/setup-python` | v5 | v6 |
| `actions/setup-node` | v3 | v6 |

### Files changed

- `.github/workflows/auto-add-issue-to-project.yml`
- `.github/workflows/cd-gcp.yml`
- `.github/workflows/deploy-aws.yml`

Closes #67

## Supersedes Dependabot PRs

Upon merge of this PR, the following open Dependabot PR should be closed as superseded:

- #40

## Test plan

- [ ] CI workflows pass on this PR (GCP CD, AWS deploy, project automation)
- [ ] Verify GitHub-hosted runners meet minimum version (≥ v2.327.1) for Node 24-based actions

Made with [Cursor](https://cursor.com)